### PR TITLE
Home page URLs for each repo

### DIFF
--- a/src/pages/[...project].astro
+++ b/src/pages/[...project].astro
@@ -54,7 +54,7 @@ const image = await getOgImage(data.homepage, 'c_fit,h_353,w_672');
         }
         <div class="px-2 py-1">
             <label for="homepage" class="font-bold">Page:</label>
-            <p id="homepage"><a class="underline" href={data.homepage}>{data.homepage}</a></p>
+            <p id="homepage"><a class="underline" href="http://${data.homepage}">{data.homepage}</a></p>
         </div>
         <div class="px-2 py-1">
             <label for="html_url" class="font-bold">Repository:</label>


### PR DESCRIPTION
Right now, your showcase pages render as: <a class="underline" href="designo-website-astro.vercel.app">designo-website-astro.vercel.app</a> which then resolve locally as https://astro-showcase.netlify.app/galielo-app/designo-website-astro/designo-website-astro.vercel.app